### PR TITLE
Fix ambiguity of clamp use

### DIFF
--- a/src/CatroModulo_CM-9.cpp
+++ b/src/CatroModulo_CM-9.cpp
@@ -93,7 +93,7 @@ void CM9Module::process(const ProcessArgs &args) {
 	gatemode = (inputsconnected == 0 && inputs[INPUT_1].isConnected() == false);
 	
 	//process selector
-	float selectorparam = clamp(round((inputs[INPUT_SEL].isConnected()) ? inputs[INPUT_SEL].getVoltage() * 0.1 * params[PARAM_SEL].getValue() : params[PARAM_SEL].getValue()), 0, 7);
+	float selectorparam = clamp(roundf((inputs[INPUT_SEL].isConnected()) ? inputs[INPUT_SEL].getVoltage() * 0.1 * params[PARAM_SEL].getValue() : params[PARAM_SEL].getValue()), 0.0, 7.0);
 
 	//stepper
 	if (inputs[INPUT_CLK].isConnected()){


### PR DESCRIPTION
The clamp function from Rack has an int and float version.
Which one was being called here was unclear, since the first arg is float but the other 2 are ints, ending up with a `clamp(float, int, int)`. This can generate a compiler warning in some conditions.

```
CatroModulo/src/CatroModulo_CM-9.cpp: In member function 'virtual void CM9Module::process(const rack::engine::Module::ProcessArgs&)':
CatroModulo/src/CatroModulo_CM-9.cpp:96:177: error: call of overloaded 'clamp(float, int, int)' is ambiguous
  float selectorparam = clamp(round((inputs[INPUT_SEL].isConnected()) ? inputs[INPUT_SEL].getVoltage() * 0.1 * params[PARAM_SEL].getValue() : params[PARAM_SEL].getValue()), 0, 7);
                                                                                                                                                                                 ^
```

We can simply do the same as already done for CM-3 module, that is, use `roundf` with the other 2 args as float.
