### PR TITLE
BPM CV output made compatible with 1 V/OCT standard

### DIFF
--- a/src/CatroModulo.hpp
+++ b/src/CatroModulo.hpp
@@ -642,7 +642,7 @@ struct CM_BpmClock {
 	}
 
 	float cvtobpm(float cv){
-		return 2.0f * (float)pow(2, cv) * 0.0166;
+		return 2.0f * (float)pow(2, cv) / 0.0166;
 		//return cv * 60.0f;
 	}
 

--- a/src/CatroModulo.hpp
+++ b/src/CatroModulo.hpp
@@ -634,16 +634,16 @@ struct CM_BpmClock {
 		
 	}
 
-	//TODO: make this compatible with 1V/oct
+	// Make this compatible with standard 1V/oct (https://vcvrack.com/manual/VoltageStandards#Pitch-and-Frequencies)
 	// Previously it used to give Hz and not 1V/oct
 	
 	float bpmtocv(float bpm){
-		return ((float)log(bpm / 60.0f) / (float)log(2)) - 1.0f;
+		return (log(bpm / 60.0f) / log(2)) - 1.0f;
 		//return bpm / 60.0f;
 	}
 
 	float cvtobpm(float cv){
-		return 120.0f * (float)pow(2, cv);
+		return 120.0f * pow(2, cv);
 		//return cv * 60.0f;
 	}
 

--- a/src/CatroModulo.hpp
+++ b/src/CatroModulo.hpp
@@ -634,12 +634,16 @@ struct CM_BpmClock {
 		
 	}
 
+	//TODO: make this compatible with CLKD (https://vcvrack.com/manual/VoltageStandards#pitch-and-frequencies)
+	
 	float bpmtocv(float bpm){
-		return bpm / 60.0f;
+		return ((float)log(bpm * 0.0166) / (float)log(2)) - 1.0f;
+		//return bpm / 60.0f;
 	}
 
 	float cvtobpm(float cv){
-		return cv * 60.0f;
+		return 2.0f * (float)pow(2, cv) * 0.0166;
+		//return cv * 60.0f;
 	}
 
 	float exttrack(float ext, float interval){

--- a/src/CatroModulo.hpp
+++ b/src/CatroModulo.hpp
@@ -634,15 +634,16 @@ struct CM_BpmClock {
 		
 	}
 
-	//TODO: make this compatible with CLKD (https://vcvrack.com/manual/VoltageStandards#pitch-and-frequencies)
+	//TODO: make this compatible with 1V/oct
+	// Previously it used to give Hz and not 1V/oct
 	
 	float bpmtocv(float bpm){
-		return ((float)log(bpm * 0.0166) / (float)log(2)) - 1.0f;
+		return ((float)log(bpm / 60.0f) / (float)log(2)) - 1.0f;
 		//return bpm / 60.0f;
 	}
 
 	float cvtobpm(float cv){
-		return 2.0f * (float)pow(2, cv) / 0.0166;
+		return 120.0f * (float)pow(2, cv);
 		//return cv * 60.0f;
 	}
 


### PR DESCRIPTION
I noticed that the function that should convert BPM to CV just change it to Hz. I propose to make it compatible with 1 V/OCT as the official documentation says it should be.